### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ Dockerfile
 Package.swift
 Package.resolved
 Sources/
-Tests/
+/Tests/
+!tests/

--- a/Aliases/oixcloud-helper
+++ b/Aliases/oixcloud-helper
@@ -1,0 +1,1 @@
+../Formula/oixcloud-external-proxy-program.rb

--- a/Formula/oixcloud-external-proxy-program.rb
+++ b/Formula/oixcloud-external-proxy-program.rb
@@ -1,0 +1,40 @@
+class OixcloudExternalProxyProgram < Formula
+  desc "Connect oixCloud nodes to Surge, or build a DHCP/DNS gateway with OpenSurge"
+  homepage "https://github.com/pickrui/oixcloud-external-proxy-program"
+  version "0.0.29"
+  license :cannot_represent
+
+  on_macos do
+    on_arm do
+      url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-arm64"
+      sha256 "7bacde236d551a38ec6596b74fc77ea824e7e488fb8e5a3b1f03247c4b1581ff"
+
+      def install
+        bin.install "oixcloud-external-proxy-program-arm64" => "oixcloud-external-proxy-program"
+        bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"
+      end
+    end
+
+    on_intel do
+      url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-amd64"
+      sha256 "7022b1f7d90b8c09c440ddf515547fa17f77f83164c4ef70ae824c18f5a0a3bf"
+
+      def install
+        bin.install "oixcloud-external-proxy-program-amd64" => "oixcloud-external-proxy-program"
+        bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"
+      end
+    end
+  end
+
+  service do
+    run [opt_bin/"oixcloud-external-proxy-program", "--tray"]
+    keep_alive true
+    log_path var/"log/oixcloud-external-proxy-program.log"
+    error_log_path var/"log/oixcloud-external-proxy-program.log"
+  end
+
+  test do
+    assert_match "oixcloud-external-proxy-program v#{version}", shell_output("#{bin}/oixcloud-external-proxy-program --version")
+    assert_match "oixcloud-external-proxy-program v#{version}", shell_output("#{bin}/oixcloud-helper --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Docker 使用 `latest`，更新命令见 [Docker 部署](docs/docker.md)
 
 ### 更多
 
-- [配置、接入模式、现有 Surge 配置和局域网访问](docs/configuration.md)
+- [Homebrew、配置、接入模式和局域网访问](docs/configuration.md)
 - [OpenSurge GUI 与 DHCP/DNS 接管](docs/opensurge.md)
 - [Docker 部署与更新](docs/docker.md)
 - [常见问题与日志](docs/troubleshooting.md)
@@ -186,7 +186,7 @@ Docker uses `latest`; see [Docker deployment](docs/docker.md#english) for update
 
 ### More
 
-- [Configuration, connection modes, existing Surge profiles, and LAN access](docs/configuration.md#english)
+- [Homebrew, configuration, connection modes, and LAN access](docs/configuration.md#english)
 - [OpenSurge GUI and DHCP/DNS takeover](docs/opensurge.md#english)
 - [Docker deployment and updates](docs/docker.md#english)
 - [Common issues and logs](docs/troubleshooting.md#english)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,29 @@
 
 ## 中文
 
+### Homebrew 安装
+
+通过 Homebrew tap 安装：
+
+```bash
+brew tap pickrui/oixcloud-external-proxy-program https://github.com/pickrui/oixcloud-external-proxy-program
+brew install oixcloud-external-proxy-program
+```
+
+安装后也可使用命令别名 `oixcloud-helper`
+
+使用 Homebrew 服务在后台运行菜单栏程序：
+
+```bash
+brew services start oixcloud-external-proxy-program
+```
+
+停止后台服务：
+
+```bash
+brew services stop oixcloud-external-proxy-program
+```
+
 ### 手动安装
 
 `启动 oixCloud.command` 已包含下载、签名校验、安装和启动流程，通常无需手动安装
@@ -166,6 +189,29 @@ rm -f ~/Library/LaunchAgents/com.oixcloud.external-proxy-program.tray.plist
 ```
 
 ## English
+
+### Homebrew installation
+
+Install via Homebrew tap:
+
+```bash
+brew tap pickrui/oixcloud-external-proxy-program https://github.com/pickrui/oixcloud-external-proxy-program
+brew install oixcloud-external-proxy-program
+```
+
+You can also use the shorthand command alias `oixcloud-helper`
+
+Run the menu bar app as a background service:
+
+```bash
+brew services start oixcloud-external-proxy-program
+```
+
+Stop the background service:
+
+```bash
+brew services stop oixcloud-external-proxy-program
+```
 
 ### Manual installation
 

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORMULA = ROOT / "Formula" / "oixcloud-external-proxy-program.rb"
+ALIAS = ROOT / "Aliases" / "oixcloud-helper"
+
+
+class FormulaTest(unittest.TestCase):
+    def test_formula_file_exists(self):
+        self.assertTrue(FORMULA.exists(), f"Formula file not found at {FORMULA}")
+
+    def test_alias_symlink_exists(self):
+        self.assertTrue(ALIAS.is_symlink(), f"Alias at {ALIAS} is not a symlink")
+        target = ALIAS.readlink()
+        self.assertEqual(str(target), "../Formula/oixcloud-external-proxy-program.rb")
+        self.assertTrue(ALIAS.resolve().exists(), f"Symlink target {ALIAS.resolve()} does not exist")
+
+    def test_ruby_syntax_is_valid(self):
+        result = subprocess.run(
+            ["ruby", "-c", str(FORMULA)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, f"Ruby syntax check failed: {result.stderr}")
+        self.assertIn("Syntax OK", result.stdout)
+
+    def test_formula_structure_and_metadata(self):
+        text = FORMULA.read_text(encoding="utf-8")
+
+        self.assertIn("class OixcloudExternalProxyProgram < Formula", text)
+        self.assertIn('homepage "https://github.com/pickrui/oixcloud-external-proxy-program"', text)
+        self.assertIn("on_macos do", text)
+        self.assertIn("on_arm do", text)
+        self.assertIn("on_intel do", text)
+        self.assertIn('bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"', text)
+        self.assertIn("service do", text)
+        self.assertIn('run [opt_bin/"oixcloud-external-proxy-program", "--tray"]', text)
+        self.assertIn("test do", text)
+        self.assertIn('assert_match "oixcloud-external-proxy-program v#{version}", shell_output("#{bin}/oixcloud-external-proxy-program --version")', text)
+        self.assertIn('assert_match "oixcloud-external-proxy-program v#{version}", shell_output("#{bin}/oixcloud-helper --version")', text)
+
+    def test_checksums_and_version_format(self):
+        text = FORMULA.read_text(encoding="utf-8")
+
+        version_match = re.search(r'version "([0-9]+(?:\.[0-9]+)+)"', text)
+        self.assertIsNotNone(version_match, "Valid version string not found in formula")
+
+        sha256_matches = re.findall(r'sha256 "([0-9a-fA-F]{64})"', text)
+        self.assertEqual(len(sha256_matches), 2, "Expected 2 sha256 checksums (arm64 and intel)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Adds Homebrew tap formula and shorthand alias support for macOS users.

### Key Changes
- **Formula (`Formula/oixcloud-external-proxy-program.rb`)**:
  - Adds support for `arm64` and `amd64` macOS builds with SHA-256 validation.
  - Installs executable binary and creates `oixcloud-helper` alias symlink in `bin/`.
  - Configures background tray service via `brew services`.
- **Alias (`Aliases/oixcloud-helper`)**:
  - Adds tap alias to enable `brew install oixcloud-helper`.
- **Documentation**:
  - Added Homebrew installation and service commands to `docs/configuration.md` (Chinese and English).
- **Tests**:
  - Added unit test suite `tests/test_formula.py` validating formula syntax, metadata, service configuration, and alias symlink resolution.