### PR TITLE
ci(homebrew): add automated formula update workflow and script

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -2,61 +2,74 @@ name: Update Homebrew Formula
 
 on:
   schedule:
-    - cron: '0 2 * * *' # Run daily at 02:00 UTC
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Specific release tag to update to (e.g. v0.0.31, leave blank for latest)'
+        description: 'Stable release tag (leave blank for latest)'
         required: false
         default: ''
   release:
     types: [published]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: homebrew-formula-update
+  cancel-in-progress: false
 
 jobs:
   update-formula:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout current formula
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Check and update formula
-        id: update
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          TAG_ARG=""
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            TAG_ARG="--tag ${{ github.event.inputs.tag }}"
+          args=()
+          if [[ -n "$RELEASE_TAG" ]]; then
+            args+=(--tag "$RELEASE_TAG")
           fi
-          python3 scripts/update_formula.py $TAG_ARG
+          python3 scripts/update_formula.py "${args[@]}"
 
       - name: Run verification tests
-        run: |
-          python3 -m unittest discover tests
+        run: python3 -m unittest discover tests -p 'test*formula.py'
 
       - name: Determine formula version
         id: version
         run: |
-          VERSION=$(python3 -c 'from pathlib import Path; import re; print(re.search(r"version \"([^\"]+)\"", Path("Formula/oixcloud-external-proxy-program.rb").read_text()).group(1))')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          python3 - <<'PY'
+          import os
+          from scripts.update_formula import DEFAULT_FORMULA_PATH, get_current_formula_version
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f'version={get_current_formula_version(DEFAULT_FORMULA_PATH)}\n')
+          PY
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "feat(homebrew): bump formula to v${{ steps.version.outputs.version }}"
-          title: "feat(homebrew): bump formula to v${{ steps.version.outputs.version }}"
-          body: |
-            ### Summary
-
-            Automated update of Homebrew formula for release `v${{ steps.version.outputs.version }}`.
-          branch: "feat/bump-formula-v${{ steps.version.outputs.version }}"
+          token: ${{ github.token }}
+          add-paths: Formula/oixcloud-external-proxy-program.rb
+          commit-message: 'feat(homebrew): bump formula to v${{ steps.version.outputs.version }}'
+          title: 'feat(homebrew): bump formula to v${{ steps.version.outputs.version }}'
+          body: 'Updates the Homebrew formula to verified release v${{ steps.version.outputs.version }}. Manual review and merge are required.'
+          branch: codex/update-homebrew-formula
           base: main
           delete-branch: true

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,62 @@
+name: Update Homebrew Formula
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Run daily at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Specific release tag to update to (e.g. v0.0.31, leave blank for latest)'
+        required: false
+        default: ''
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Check and update formula
+        id: update
+        run: |
+          TAG_ARG=""
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG_ARG="--tag ${{ github.event.inputs.tag }}"
+          fi
+          python3 scripts/update_formula.py $TAG_ARG
+
+      - name: Run verification tests
+        run: |
+          python3 -m unittest discover tests
+
+      - name: Determine formula version
+        id: version
+        run: |
+          VERSION=$(python3 -c 'from pathlib import Path; import re; print(re.search(r"version \"([^\"]+)\"", Path("Formula/oixcloud-external-proxy-program.rb").read_text()).group(1))')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "feat(homebrew): bump formula to v${{ steps.version.outputs.version }}"
+          title: "feat(homebrew): bump formula to v${{ steps.version.outputs.version }}"
+          body: |
+            ### Summary
+
+            Automated update of Homebrew formula for release `v${{ steps.version.outputs.version }}`.
+          branch: "feat/bump-formula-v${{ steps.version.outputs.version }}"
+          base: main
+          delete-branch: true

--- a/scripts/update_formula.py
+++ b/scripts/update_formula.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Automatically check and update the Homebrew formula for oixcloud-external-proxy-program."""
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+import urllib.request
+
+REPO = "pickrui/oixcloud-external-proxy-program"
+DEFAULT_FORMULA_PATH = Path(__file__).resolve().parents[1] / "Formula" / "oixcloud-external-proxy-program.rb"
+
+
+def get_current_formula_version(formula_path: Path) -> str:
+    content = formula_path.read_text(encoding="utf-8")
+    match = re.search(r'version "([0-9]+(?:\.[0-9]+)+)"', content)
+    if not match:
+        raise ValueError(f"Could not find version string in {formula_path}")
+    return match.group(1)
+
+
+def fetch_release_metadata(repo: str, tag: str | None = None) -> dict:
+    if tag:
+        tag_name = tag if tag.startswith("v") else f"v{tag}"
+        url = f"https://api.github.com/repos/{repo}/releases/tags/{tag_name}"
+    else:
+        url = f"https://api.github.com/repos/{repo}/releases/latest"
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "oixcloud-formula-updater",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def parse_sha256sums_content(text: str) -> dict[str, str]:
+    result = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and len(parts[0]) == 64:
+            sha, filename = parts[0], parts[1].lstrip("*")
+            result[filename] = sha.lower()
+    return result
+
+
+def fetch_sha256sums_from_release(release_data: dict, repo: str) -> dict[str, str]:
+    tag_name = release_data.get("tag_name", "")
+    sha256sums_url = None
+    for asset in release_data.get("assets", []):
+        if asset.get("name") == "SHA256SUMS":
+            sha256sums_url = asset.get("browser_download_url")
+            break
+
+    if not sha256sums_url and tag_name:
+        sha256sums_url = f"https://github.com/{repo}/releases/download/{tag_name}/SHA256SUMS"
+
+    if not sha256sums_url:
+        raise ValueError(f"Could not find SHA256SUMS asset in release {tag_name}")
+
+    req = urllib.request.Request(
+        sha256sums_url,
+        headers={"User-Agent": "oixcloud-formula-updater"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return parse_sha256sums_content(resp.read().decode("utf-8"))
+
+
+def update_formula_text(
+    content: str,
+    new_version: str,
+    arm64_sha: str,
+    amd64_sha: str,
+    legacy_sha: str,
+) -> str:
+    # 1. Update version
+    content, n_ver = re.subn(r'version "[^"]+"', f'version "{new_version}"', content, count=1)
+    if n_ver != 1:
+        raise ValueError("Failed to replace version in formula")
+
+    # 2. Update arm64 sha256
+    content, n_arm = re.subn(
+        r'(on_arm do\s+url [^\n]+\n\s+sha256 )"[^"]+"',
+        rf'\1"{arm64_sha}"',
+        content,
+        count=1,
+    )
+    if n_arm != 1:
+        raise ValueError("Failed to replace arm64 sha256 in formula")
+
+    # 3. Update amd64/intel sha256
+    content, n_amd = re.subn(
+        r'(on_intel do\s+url [^\n]+\n\s+sha256 )"[^"]+"',
+        rf'\1"{amd64_sha}"',
+        content,
+        count=1,
+    )
+    if n_amd != 1:
+        raise ValueError("Failed to replace amd64 sha256 in formula")
+
+    # 4. Update legacy sha256
+    content, n_leg = re.subn(
+        r'(oixcloud-external-proxy-program-legacy"\n\s+sha256 )"[^"]+"',
+        rf'\1"{legacy_sha}"',
+        content,
+        count=1,
+    )
+    if n_leg != 1:
+        raise ValueError("Failed to replace legacy sha256 in formula")
+
+    return content
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update Homebrew formula for oixcloud-external-proxy-program")
+    parser.add_argument("--repo", default=REPO, help="GitHub repository (owner/repo)")
+    parser.add_argument("--tag", help="Specific release tag to update to (e.g. v0.0.30)")
+    parser.add_argument("--formula", type=Path, default=DEFAULT_FORMULA_PATH, help="Path to formula file")
+    parser.add_argument("--check", action="store_true", help="Only check for updates, do not write changes")
+    args = parser.parse_args()
+
+    formula_path = args.formula
+    if not formula_path.exists():
+        print(f"Error: Formula file not found: {formula_path}", file=sys.stderr)
+        return 1
+
+    current_version = get_current_formula_version(formula_path)
+    print(f"Current formula version: {current_version}")
+
+    print(f"Fetching latest release from {args.repo}...")
+    try:
+        release_data = fetch_release_metadata(args.repo, args.tag)
+    except Exception as e:
+        print(f"Error fetching release metadata: {e}", file=sys.stderr)
+        return 1
+
+    tag_name = release_data.get("tag_name", "")
+    target_version = tag_name.lstrip("v")
+    if not target_version:
+        print("Error: Could not determine release version from tag", file=sys.stderr)
+        return 1
+
+    print(f"Target release version: {target_version} ({tag_name})")
+
+    checksums = fetch_sha256sums_from_release(release_data, args.repo)
+    arm64_sha = checksums.get("oixcloud-external-proxy-program-arm64")
+    amd64_sha = checksums.get("oixcloud-external-proxy-program-amd64")
+    legacy_sha = checksums.get("oixcloud-external-proxy-program-legacy")
+
+    if not (arm64_sha and amd64_sha and legacy_sha):
+        print(
+            f"Error: Missing required asset checksums in release {tag_name}.\nFound: {checksums}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Found checksums:\n  arm64:  {arm64_sha}\n  amd64:  {amd64_sha}\n  legacy: {legacy_sha}")
+
+    content = formula_path.read_text(encoding="utf-8")
+    updated_content = update_formula_text(
+        content,
+        target_version,
+        arm64_sha,
+        amd64_sha,
+        legacy_sha,
+    )
+
+    if content == updated_content:
+        print(f"Formula {formula_path.name} is already up to date with {target_version}.")
+        return 0
+
+    if args.check:
+        print(f"Update available: {current_version} -> {target_version}")
+        return 0
+
+    formula_path.write_text(updated_content, encoding="utf-8")
+    print(f"Successfully updated {formula_path} to {target_version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_formula.py
+++ b/scripts/update_formula.py
@@ -1,41 +1,70 @@
 #!/usr/bin/env python3
-"""Automatically check and update the Homebrew formula for oixcloud-external-proxy-program."""
+"""Update the Homebrew formula from a verified stable GitHub release."""
 
 import argparse
+import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import sys
+import tempfile
 import urllib.request
 
 REPO = "pickrui/oixcloud-external-proxy-program"
 DEFAULT_FORMULA_PATH = Path(__file__).resolve().parents[1] / "Formula" / "oixcloud-external-proxy-program.rb"
+ASSETS = tuple(f"oixcloud-external-proxy-program-{arch}" for arch in ("arm64", "amd64", "legacy"))
+VERSION_PATTERN = r"(?:0|[1-9][0-9]*)(?:\.(?:0|[1-9][0-9]*)){1,2}"
+
+
+def normalize_tag(tag: str) -> str:
+    if not isinstance(tag, str) or not re.fullmatch(rf"v?{VERSION_PATTERN}", tag):
+        raise ValueError("Expected a stable numeric release tag, for example v0.0.31")
+    return tag if tag.startswith("v") else f"v{tag}"
+
+
+def validate_repo(repo: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+", repo) or repo.split("/")[1] in (".", ".."):
+        raise ValueError("Expected a GitHub owner/repository")
+
+
+def validate_sha256(value: str) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", value):
+        raise ValueError("Invalid SHA-256 digest")
+    return value.lower()
 
 
 def get_current_formula_version(formula_path: Path) -> str:
-    content = formula_path.read_text(encoding="utf-8")
-    match = re.search(r'version "([0-9]+(?:\.[0-9]+)+)"', content)
-    if not match:
-        raise ValueError(f"Could not find version string in {formula_path}")
-    return match.group(1)
+    matches = re.findall(r'^\s*version "([^"\n]+)"\s*$', formula_path.read_text(encoding="utf-8"), re.MULTILINE)
+    if len(matches) != 1:
+        raise ValueError("Expected exactly one formula version")
+    return normalize_tag(matches[0])[1:]
+
+
+def download(url: str, *, limit: int, authenticated: bool = False) -> bytes:
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "oixcloud-formula-updater"}
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if authenticated and token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        body = response.read(limit + 1)
+    if len(body) > limit:
+        raise ValueError("Release response exceeds the size limit")
+    return body
 
 
 def fetch_release_metadata(repo: str, tag: str | None = None) -> dict:
-    if tag:
-        tag_name = tag if tag.startswith("v") else f"v{tag}"
-        url = f"https://api.github.com/repos/{repo}/releases/tags/{tag_name}"
-    else:
-        url = f"https://api.github.com/repos/{repo}/releases/latest"
-
-    req = urllib.request.Request(
-        url,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "oixcloud-formula-updater",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    validate_repo(repo)
+    suffix = f"tags/{normalize_tag(tag)}" if tag else "latest"
+    release = json.loads(download(f"https://api.github.com/repos/{repo}/releases/{suffix}",
+                                  limit=1024 * 1024, authenticated=True))
+    if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+        raise ValueError("Only published stable releases are supported")
+    actual = normalize_tag(release.get("tag_name", ""))
+    if not release["tag_name"].startswith("v") or (tag and actual != normalize_tag(tag)):
+        raise ValueError("Release tag does not match the request")
+    return release
 
 
 def parse_sha256sums_content(text: str) -> dict[str, str]:
@@ -45,144 +74,124 @@ def parse_sha256sums_content(text: str) -> dict[str, str]:
         if not line or line.startswith("#"):
             continue
         parts = line.split()
-        if len(parts) >= 2 and len(parts[0]) == 64:
-            sha, filename = parts[0], parts[1].lstrip("*")
-            result[filename] = sha.lower()
+        if len(parts) != 2:
+            raise ValueError("Malformed SHA256SUMS line")
+        sha, filename = parts[0], parts[1].removeprefix("*")
+        if not filename or filename in result:
+            raise ValueError(f"Duplicate or empty checksum filename: {filename}")
+        result[filename] = validate_sha256(sha)
     return result
 
 
+def release_assets(release_data: dict, repo: str) -> dict[str, dict]:
+    validate_repo(repo)
+    tag = normalize_tag(release_data.get("tag_name", ""))
+    assets = {}
+    entries = release_data.get("assets", [])
+    if not isinstance(entries, list):
+        raise ValueError("Expected release assets to be a list")
+    for asset in entries:
+        if not isinstance(asset, dict):
+            raise ValueError("Invalid release asset metadata")
+        name = asset.get("name")
+        if name not in (*ASSETS, "SHA256SUMS"):
+            continue
+        expected = f"https://github.com/{repo}/releases/download/{tag}/{name}"
+        if name in assets or asset.get("browser_download_url") != expected:
+            raise ValueError(f"Duplicate asset or unexpected download URL: {name}")
+        assets[name] = asset
+    missing = set((*ASSETS, "SHA256SUMS")) - assets.keys()
+    if missing:
+        raise ValueError(f"Missing release assets: {', '.join(sorted(missing))}")
+    return assets
+
+
+def check_asset_digest(asset: dict, sha256: str) -> None:
+    digest = asset.get("digest")
+    if digest is None:
+        return  # Older GitHub releases may not expose asset digests.
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError(f"Invalid GitHub asset digest: {asset['name']}")
+    if validate_sha256(digest[7:]) != sha256:
+        raise ValueError(f"GitHub asset digest disagrees with SHA256SUMS: {asset['name']}")
+
+
 def fetch_sha256sums_from_release(release_data: dict, repo: str) -> dict[str, str]:
-    tag_name = release_data.get("tag_name", "")
-    sha256sums_url = None
-    for asset in release_data.get("assets", []):
-        if asset.get("name") == "SHA256SUMS":
-            sha256sums_url = asset.get("browser_download_url")
-            break
-
-    if not sha256sums_url and tag_name:
-        sha256sums_url = f"https://github.com/{repo}/releases/download/{tag_name}/SHA256SUMS"
-
-    if not sha256sums_url:
-        raise ValueError(f"Could not find SHA256SUMS asset in release {tag_name}")
-
-    req = urllib.request.Request(
-        sha256sums_url,
-        headers={"User-Agent": "oixcloud-formula-updater"},
-    )
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        return parse_sha256sums_content(resp.read().decode("utf-8"))
+    assets = release_assets(release_data, repo)
+    body = download(assets["SHA256SUMS"]["browser_download_url"], limit=64 * 1024)
+    check_asset_digest(assets["SHA256SUMS"], hashlib.sha256(body).hexdigest())
+    checksums = parse_sha256sums_content(body.decode("utf-8"))
+    for name in ASSETS:
+        if name not in checksums:
+            raise ValueError(f"Missing checksum: {name}")
+        check_asset_digest(assets[name], checksums[name])
+    return checksums
 
 
-def update_formula_text(
-    content: str,
-    new_version: str,
-    arm64_sha: str,
-    amd64_sha: str,
-    legacy_sha: str,
-) -> str:
-    # 1. Update version
-    content, n_ver = re.subn(r'version "[^"]+"', f'version "{new_version}"', content, count=1)
-    if n_ver != 1:
-        raise ValueError("Failed to replace version in formula")
-
-    # 2. Update arm64 sha256
-    content, n_arm = re.subn(
-        r'(on_arm do\s+url [^\n]+\n\s+sha256 )"[^"]+"',
-        rf'\1"{arm64_sha}"',
-        content,
-        count=1,
-    )
-    if n_arm != 1:
-        raise ValueError("Failed to replace arm64 sha256 in formula")
-
-    # 3. Update amd64/intel sha256
-    content, n_amd = re.subn(
-        r'(on_intel do\s+url [^\n]+\n\s+sha256 )"[^"]+"',
-        rf'\1"{amd64_sha}"',
-        content,
-        count=1,
-    )
-    if n_amd != 1:
-        raise ValueError("Failed to replace amd64 sha256 in formula")
-
-    # 4. Update legacy sha256
-    content, n_leg = re.subn(
-        r'(oixcloud-external-proxy-program-legacy"\n\s+sha256 )"[^"]+"',
-        rf'\1"{legacy_sha}"',
-        content,
-        count=1,
-    )
-    if n_leg != 1:
-        raise ValueError("Failed to replace legacy sha256 in formula")
-
+def update_formula_text(content: str, new_version: str, arm64_sha: str,
+                        amd64_sha: str, legacy_sha: str) -> str:
+    version = normalize_tag(new_version)[1:]
+    digests = [validate_sha256(value) for value in (arm64_sha, amd64_sha, legacy_sha)]
+    content, count = re.subn(r'(^\s*version )"[^"\n]+"', lambda m: f'{m[1]}"{version}"',
+                             content, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError("Expected exactly one formula version")
+    for asset, sha256 in zip(ASSETS, digests):
+        pattern = rf'(^[ \t]*url "[^"\n]*/{re.escape(asset)}"\n[ \t]*sha256 )"[^"\n]+"'
+        content, count = re.subn(pattern, lambda m: f'{m[1]}"{sha256}"', content, flags=re.MULTILINE)
+        if count != 1:
+            raise ValueError(f"Expected exactly one formula URL/checksum for {asset}")
     return content
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Update Homebrew formula for oixcloud-external-proxy-program")
-    parser.add_argument("--repo", default=REPO, help="GitHub repository (owner/repo)")
-    parser.add_argument("--tag", help="Specific release tag to update to (e.g. v0.0.30)")
-    parser.add_argument("--formula", type=Path, default=DEFAULT_FORMULA_PATH, help="Path to formula file")
-    parser.add_argument("--check", action="store_true", help="Only check for updates, do not write changes")
-    args = parser.parse_args()
+def version_tuple(version: str) -> tuple[int, ...]:
+    parts = tuple(int(value) for value in normalize_tag(version)[1:].split("."))
+    return parts + (0,) * (3 - len(parts))
 
-    formula_path = args.formula
-    if not formula_path.exists():
-        print(f"Error: Formula file not found: {formula_path}", file=sys.stderr)
-        return 1
 
-    current_version = get_current_formula_version(formula_path)
-    print(f"Current formula version: {current_version}")
-
-    print(f"Fetching latest release from {args.repo}...")
+def write_atomically(path: Path, text: str) -> None:
+    temporary = None
     try:
-        release_data = fetch_release_metadata(args.repo, args.tag)
-    except Exception as e:
-        print(f"Error fetching release metadata: {e}", file=sys.stderr)
-        return 1
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+            temporary = Path(handle.name)
+            handle.write(text)
+        temporary.chmod(path.stat().st_mode & 0o777)
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
 
-    tag_name = release_data.get("tag_name", "")
-    target_version = tag_name.lstrip("v")
-    if not target_version:
-        print("Error: Could not determine release version from tag", file=sys.stderr)
-        return 1
 
-    print(f"Target release version: {target_version} ({tag_name})")
-
-    checksums = fetch_sha256sums_from_release(release_data, args.repo)
-    arm64_sha = checksums.get("oixcloud-external-proxy-program-arm64")
-    amd64_sha = checksums.get("oixcloud-external-proxy-program-amd64")
-    legacy_sha = checksums.get("oixcloud-external-proxy-program-legacy")
-
-    if not (arm64_sha and amd64_sha and legacy_sha):
-        print(
-            f"Error: Missing required asset checksums in release {tag_name}.\nFound: {checksums}",
-            file=sys.stderr,
-        )
-        return 1
-
-    print(f"Found checksums:\n  arm64:  {arm64_sha}\n  amd64:  {amd64_sha}\n  legacy: {legacy_sha}")
-
-    content = formula_path.read_text(encoding="utf-8")
-    updated_content = update_formula_text(
-        content,
-        target_version,
-        arm64_sha,
-        amd64_sha,
-        legacy_sha,
-    )
-
-    if content == updated_content:
-        print(f"Formula {formula_path.name} is already up to date with {target_version}.")
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=REPO)
+    parser.add_argument("--tag", help="Specific stable release tag, or latest when omitted")
+    parser.add_argument("--formula", type=Path, default=DEFAULT_FORMULA_PATH)
+    parser.add_argument("--check", action="store_true", help="Check without changing the formula")
+    args = parser.parse_args()
+    try:
+        validate_repo(args.repo)
+        if args.tag:
+            normalize_tag(args.tag)
+        current_version = get_current_formula_version(args.formula)
+        release = fetch_release_metadata(args.repo, args.tag)
+        target_version = normalize_tag(release["tag_name"])[1:]
+        if version_tuple(target_version) < version_tuple(current_version):
+            raise ValueError(f"Refusing to downgrade {current_version} to {target_version}")
+        checksums = fetch_sha256sums_from_release(release, args.repo)
+        content = args.formula.read_text(encoding="utf-8")
+        updated = update_formula_text(content, target_version, *(checksums[name] for name in ASSETS))
+        if content == updated:
+            print(f"Formula is already up to date: {target_version}")
+        elif args.check:
+            print(f"Update available: {current_version} -> {target_version}")
+        else:
+            write_atomically(args.formula, updated)
+            print(f"Updated formula: {current_version} -> {target_version}")
         return 0
-
-    if args.check:
-        print(f"Update available: {current_version} -> {target_version}")
-        return 0
-
-    formula_path.write_text(updated_content, encoding="utf-8")
-    print(f"Successfully updated {formula_path} to {target_version}.")
-    return 0
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from update_formula import (
+    get_current_formula_version,
+    parse_sha256sums_content,
+    update_formula_text,
+)
+
+
+class UpdateFormulaTest(unittest.TestCase):
+    def setUp(self):
+        self.formula_path = ROOT / "Formula" / "oixcloud-external-proxy-program.rb"
+
+    def test_get_current_formula_version(self):
+        version = get_current_formula_version(self.formula_path)
+        self.assertRegex(version, r"^[0-9]+(\.[0-9]+)+$")
+
+    def test_parse_sha256sums_content(self):
+        text = """
+30fc2e5c8c4cafa049d4a283bc6444123adf38bda304ff4d8c4af9f0005d16d3  oixcloud-external-proxy-program-arm64
+6cfa1e5e3ab71443a34d2dc9e523d783b4737a32d0d71db665b39b891a95e8d6  oixcloud-external-proxy-program-amd64
+afd585202b9e55ce361774c66e267e15c2d9f447767c7fa34f262655b8129269  oixcloud-external-proxy-program-legacy
+"""
+        sums = parse_sha256sums_content(text)
+        self.assertEqual(
+            sums["oixcloud-external-proxy-program-arm64"],
+            "30fc2e5c8c4cafa049d4a283bc6444123adf38bda304ff4d8c4af9f0005d16d3",
+        )
+        self.assertEqual(
+            sums["oixcloud-external-proxy-program-amd64"],
+            "6cfa1e5e3ab71443a34d2dc9e523d783b4737a32d0d71db665b39b891a95e8d6",
+        )
+        self.assertEqual(
+            sums["oixcloud-external-proxy-program-legacy"],
+            "afd585202b9e55ce361774c66e267e15c2d9f447767c7fa34f262655b8129269",
+        )
+
+    def test_update_formula_text(self):
+        sample_formula = """class OixcloudExternalProxyProgram < Formula
+  desc "Connect oixCloud nodes to Surge, or build a DHCP/DNS gateway with OpenSurge"
+  homepage "https://github.com/pickrui/oixcloud-external-proxy-program"
+  version "0.0.30"
+  license :cannot_represent
+
+  on_macos do
+    if MacOS.version >= :sonoma
+      on_arm do
+        url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-arm64"
+        sha256 "old_arm_sha"
+
+        def install
+          bin.install "oixcloud-external-proxy-program-arm64" => "oixcloud-external-proxy-program"
+          bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"
+        end
+      end
+
+      on_intel do
+        url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-amd64"
+        sha256 "old_amd_sha"
+
+        def install
+          bin.install "oixcloud-external-proxy-program-amd64" => "oixcloud-external-proxy-program"
+          bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"
+        end
+      end
+    else
+      url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-legacy"
+      sha256 "old_legacy_sha"
+
+      def install
+        bin.install "oixcloud-external-proxy-program-legacy" => "oixcloud-external-proxy-program"
+        bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"
+      end
+    end
+  end
+end
+"""
+        updated = update_formula_text(
+            sample_formula,
+            "0.0.31",
+            "new_arm_sha",
+            "new_amd_sha",
+            "new_legacy_sha",
+        )
+        self.assertIn('version "0.0.31"', updated)
+        self.assertIn('sha256 "new_arm_sha"', updated)
+        self.assertIn('sha256 "new_amd_sha"', updated)
+        self.assertIn('sha256 "new_legacy_sha"', updated)
+        self.assertNotIn("old_arm_sha", updated)
+        self.assertNotIn("old_amd_sha", updated)
+        self.assertNotIn("old_legacy_sha", updated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_formula.py
+++ b/tests/test_update_formula.py
@@ -1,9 +1,17 @@
 from pathlib import Path
 import sys
+import contextlib
+import hashlib
+import io
+import json
+import tempfile
+from unittest.mock import patch
 import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+import update_formula
 
 from update_formula import (
     get_current_formula_version,
@@ -51,7 +59,7 @@ afd585202b9e55ce361774c66e267e15c2d9f447767c7fa34f262655b8129269  oixcloud-exter
     if MacOS.version >= :sonoma
       on_arm do
         url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-arm64"
-        sha256 "old_arm_sha"
+        sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
         def install
           bin.install "oixcloud-external-proxy-program-arm64" => "oixcloud-external-proxy-program"
@@ -61,7 +69,7 @@ afd585202b9e55ce361774c66e267e15c2d9f447767c7fa34f262655b8129269  oixcloud-exter
 
       on_intel do
         url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-amd64"
-        sha256 "old_amd_sha"
+        sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
         def install
           bin.install "oixcloud-external-proxy-program-amd64" => "oixcloud-external-proxy-program"
@@ -70,7 +78,7 @@ afd585202b9e55ce361774c66e267e15c2d9f447767c7fa34f262655b8129269  oixcloud-exter
       end
     else
       url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-legacy"
-      sha256 "old_legacy_sha"
+      sha256 "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 
       def install
         bin.install "oixcloud-external-proxy-program-legacy" => "oixcloud-external-proxy-program"
@@ -83,17 +91,118 @@ end
         updated = update_formula_text(
             sample_formula,
             "0.0.31",
-            "new_arm_sha",
-            "new_amd_sha",
-            "new_legacy_sha",
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "2222222222222222222222222222222222222222222222222222222222222222",
+            "3333333333333333333333333333333333333333333333333333333333333333",
         )
         self.assertIn('version "0.0.31"', updated)
-        self.assertIn('sha256 "new_arm_sha"', updated)
-        self.assertIn('sha256 "new_amd_sha"', updated)
-        self.assertIn('sha256 "new_legacy_sha"', updated)
-        self.assertNotIn("old_arm_sha", updated)
-        self.assertNotIn("old_amd_sha", updated)
-        self.assertNotIn("old_legacy_sha", updated)
+        self.assertIn('sha256 "1111111111111111111111111111111111111111111111111111111111111111"', updated)
+        self.assertIn('sha256 "2222222222222222222222222222222222222222222222222222222222222222"', updated)
+        self.assertIn('sha256 "3333333333333333333333333333333333333333333333333333333333333333"', updated)
+        self.assertNotIn("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", updated)
+        self.assertNotIn("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", updated)
+        self.assertNotIn("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", updated)
+
+
+class ReleaseValidationTest(unittest.TestCase):
+    def release(self, tag="v0.0.32"):
+        assets = []
+        for index, name in enumerate(update_formula.ASSETS):
+            assets.append({"name": name, "digest": "sha256:" + str(index + 1) * 64,
+                           "browser_download_url": f"https://github.com/{update_formula.REPO}/releases/download/{tag}/{name}"})
+        text = "".join(f"{asset['digest'][7:]}  {asset['name']}\n" for asset in assets).encode()
+        assets.append({"name": "SHA256SUMS", "digest": "sha256:" + hashlib.sha256(text).hexdigest(),
+                       "browser_download_url": f"https://github.com/{update_formula.REPO}/releases/download/{tag}/SHA256SUMS"})
+        return {"tag_name": tag, "draft": False, "prerelease": False, "assets": assets}, text
+
+    def test_rejects_unsafe_tags_before_network_access(self):
+        for tag in ['v1.2.3"; touch /tmp/invalid', "$(id)", "v1.2.3-beta", "../latest", "vv1.2.3"]:
+            with self.subTest(tag=tag), patch.object(update_formula, "download") as network:
+                with self.assertRaises(ValueError):
+                    update_formula.fetch_release_metadata(update_formula.REPO, tag)
+                network.assert_not_called()
+
+    def test_rejects_draft_prerelease_and_mismatched_metadata(self):
+        for edit in [{"draft": True}, {"prerelease": True}, {"tag_name": "v0.0.33"}]:
+            release, _ = self.release()
+            release.update(edit)
+            with self.subTest(edit=edit), patch.object(update_formula, "download", return_value=json.dumps(release).encode()):
+                with self.assertRaises(ValueError):
+                    update_formula.fetch_release_metadata(update_formula.REPO, "v0.0.32")
+
+    def test_checksums_reject_nonhex_duplicates_and_malformed_lines(self):
+        for body in ["z" * 64 + "  binary", "a" * 64 + "  binary\n" + "b" * 64 + "  binary",
+                     "a" * 64 + "  binary extra", "not-a-checksum"]:
+            with self.subTest(body=body), self.assertRaises(ValueError):
+                parse_sha256sums_content(body)
+
+    def test_validates_manifest_and_all_binary_digests(self):
+        release, body = self.release()
+        with patch.object(update_formula, "download", return_value=body):
+            self.assertEqual(len(update_formula.fetch_sha256sums_from_release(release, update_formula.REPO)), 3)
+        for index in range(4):
+            release, body = self.release()
+            release["assets"][index]["digest"] = "sha256:" + "f" * 64
+            with self.subTest(index=index), patch.object(update_formula, "download", return_value=body):
+                with self.assertRaises(ValueError):
+                    update_formula.fetch_sha256sums_from_release(release, update_formula.REPO)
+
+    def test_rejects_missing_assets_and_untrusted_urls_before_download(self):
+        for change in ["missing", "duplicate", "url"]:
+            release, _ = self.release()
+            if change == "missing":
+                release["assets"].pop(0)
+            elif change == "duplicate":
+                release["assets"].append(dict(release["assets"][0]))
+            else:
+                release["assets"][-1]["browser_download_url"] = "https://example.invalid/SHA256SUMS"
+            with self.subTest(change=change), patch.object(update_formula, "download") as network:
+                with self.assertRaises(ValueError):
+                    update_formula.fetch_sha256sums_from_release(release, update_formula.REPO)
+                network.assert_not_called()
+
+    def test_missing_or_duplicate_formula_asset_is_not_partially_rewritten(self):
+        content = update_formula.DEFAULT_FORMULA_PATH.read_text()
+        malformed = content.replace("-legacy\"", "-missing\"")
+        for text in [malformed, content + content]:
+            with self.assertRaises(ValueError):
+                update_formula_text(text, "0.0.32", "1" * 64, "2" * 64, "3" * 64)
+
+    def test_check_mode_and_failed_release_keep_formula_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            formula = Path(directory) / "formula.rb"
+            original = update_formula.DEFAULT_FORMULA_PATH.read_text()
+            formula.write_text(original)
+            release, body = self.release()
+            for check, fail in [(True, False), (False, True)]:
+                argv = ["update_formula.py", "--formula", str(formula)] + (["--check"] if check else [])
+                with patch.object(sys, "argv", argv), patch.object(update_formula, "fetch_release_metadata", return_value=release), \
+                     patch.object(update_formula, "download", side_effect=OSError("unavailable") if fail else None, return_value=body), \
+                     contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                    self.assertEqual(update_formula.main(), 1 if fail else 0)
+                self.assertEqual(formula.read_text(), original)
+
+    def test_rejects_downgrade_without_fetching_checksums(self):
+        with tempfile.TemporaryDirectory() as directory:
+            formula = Path(directory) / "formula.rb"
+            formula.write_text('version "0.0.31"\n')
+            release, _ = self.release("v0.0.30")
+            with patch.object(sys, "argv", ["update_formula.py", "--formula", str(formula)]), \
+                 patch.object(update_formula, "fetch_release_metadata", return_value=release), \
+                 patch.object(update_formula, "fetch_sha256sums_from_release") as checksums, \
+                 contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(update_formula.main(), 1)
+                checksums.assert_not_called()
+            self.assertEqual(formula.read_text(), 'version "0.0.31"\n')
+
+    def test_atomic_write_preserves_original_when_replace_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "formula.rb"
+            path.write_text("original")
+            with patch.object(Path, "replace", side_effect=OSError("denied")), self.assertRaises(OSError):
+                update_formula.write_atomically(path, "new")
+            self.assertEqual(path.read_text(), "original")
+            self.assertEqual(list(Path(directory).iterdir()), [path])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Keeps the Homebrew formula current by proposing a reviewed update after a published release, on a daily check, or through manual dispatch. Updates always start from current main and use one reusable PR branch; merging remains manual.

The updater validates stable tags, asset URLs, unique hexadecimal checksums, and GitHub asset digests; it rejects downgrades and preserves the formula on failures. Workflow inputs are passed through quoted environment variables, actions are pinned, and only the Formula file can be committed.

Validation: 28 repository tests, actionlint, malicious-input rejection, and an authenticated check against published v0.0.31 passed. The workflow runs the 17 formula-related tests on Ubuntu.
