### PR TITLE
fix(homebrew): add top-level URL to pass multi-platform tap audit

### DIFF
--- a/Formula/oixcloud-external-proxy-program.rb
+++ b/Formula/oixcloud-external-proxy-program.rb
@@ -4,6 +4,9 @@ class OixcloudExternalProxyProgram < Formula
   version "0.0.31"
   license :cannot_represent
 
+  url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-legacy"
+  sha256 "9e1a1b5d1bb1d3c5da87e26ad3dbe4c2869907214dbae4f4c63009787b0764ba"
+
   depends_on macos: :big_sur
 
   on_macos do
@@ -30,9 +33,6 @@ class OixcloudExternalProxyProgram < Formula
     end
 
     on_ventura :or_older do
-      url "https://github.com/pickrui/oixcloud-external-proxy-program/releases/download/v#{version}/oixcloud-external-proxy-program-legacy"
-      sha256 "9e1a1b5d1bb1d3c5da87e26ad3dbe4c2869907214dbae4f4c63009787b0764ba"
-
       def install
         bin.install "oixcloud-external-proxy-program-legacy" => "oixcloud-external-proxy-program"
         bin.install_symlink bin/"oixcloud-external-proxy-program" => "oixcloud-helper"


### PR DESCRIPTION
Resolves a `brew tap pickrui/oixcloud-external-proxy-program` failure caused by Homebrew's multi-platform audit (`Readall.valid_tap?`).

### Problem
Homebrew audits formula syntax against both macOS and Linux targets (`x86_64_linux`, `arm64_linux`). Because previously all `url` definitions were scoped inside `on_macos do`, Linux audit simulations lacked any valid URL and failed with:

```
Error: Invalid formula (x86_64_linux): .../Formula/oixcloud-external-proxy-program.rb
pickrui/oixcloud-external-proxy-program/oixcloud-external-proxy-program: formula requires at least a URL
Error: Invalid formula (arm64_linux): ...
Error: Cannot tap pickrui/oixcloud-external-proxy-program: invalid syntax in tap!
```
<img width="845" height="135" alt="image" src="https://github.com/user-attachments/assets/e800f609-9093-4ea6-947d-23df106207da" />


### Solution
- Declare top-level fallback `url` and `sha256` for `legacy` so Homebrew's syntax audit succeeds across all simulated platforms.
- `on_ventura :or_older do` inherits the top-level URL without redundant redeclarations.
- Sonoma and newer macOS targets continue to override with architecture-specific `arm64` and `amd64` binaries as expected.
- Fully compatible with `scripts/update_formula.py` and `.github/workflows/update-formula.yml`.

### Validation
- Tested with `Readall.valid_tap?` and all 16 `OnSystem::ALL_OS_ARCH_COMBINATIONS` in Homebrew.
- All 31 existing unit tests passed (`python3 -m unittest discover tests`).
- Validated dry-run update with `scripts/update_formula.py`.